### PR TITLE
make the variable next_n_days dynamic in streamlit

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -6,7 +6,7 @@ from availability import get_availability
 st.title('Vaccine Availability')
 st.markdown('Contribute on [GitHub](https://github.com/bhavsarpratik/vaccine_availability)')
 
-next_n_days = 3
+next_n_days = st.sidebar.slider('Next n days',min_value=1,max_value=30,step=1)
 
 data = pd.read_csv('districts.csv')
 mapper = {}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/66209958/116814051-6d1b6500-ab74-11eb-83df-c5685814b15d.png)

`next_n_days` in `streamlit_app.py` was fixed to 3, but now it will have an user-defined value.

![image](https://user-images.githubusercontent.com/66209958/116814110-c7b4c100-ab74-11eb-8f7e-11fbd25f10e0.png)

the streamlit slider returns an integer in the range 1 to 30